### PR TITLE
Change canonicalisation by repr() for StatefulSpecies

### DIFF
--- a/pyvalem/reaction.py
+++ b/pyvalem/reaction.py
@@ -111,10 +111,25 @@ class Reaction:
         return n, ss
 
     def __repr__(self):
-        reactants = ' + '.join(sorted(self._get_repr_term(n, r)
-                                    for n, r in self.reactants))
-        products = ' + '.join(sorted(self._get_repr_term(n, p)
-                                    for n, p in self.products))
+        # electron, positron and photon will go first, M will go last.
+        sort_key = {
+            'e-': -1, 'e+': -1, 'hv': -1, 'hν': -1, 'M': 1
+        }
+        reactants_sorted = sorted(
+            self.reactants,
+            key=lambda nr: (sort_key.get(nr[1].formula.formula, 0),
+                            repr(nr[1]))
+        )
+        products_sorted = sorted(
+            self.products,
+            key=lambda np: (sort_key.get(np[1].formula.formula, 0),
+                            repr(np[1]))
+        )
+
+        reactants = ' + '.join(self._get_repr_term(n, r)
+                               for n, r in reactants_sorted)
+        products = ' + '.join(self._get_repr_term(n, p)
+                              for n, p in products_sorted)
         if products:
             return '{} {} {}'.format(reactants, self.sep, products)
         return '{} {}'.format(reactants, self.sep)

--- a/pyvalem/state_parser.py
+++ b/pyvalem/state_parser.py
@@ -26,10 +26,10 @@ STATES = OrderedDict([
     (MolecularTermSymbol, 2),
     (VibrationalState, 3),
     (RotationalState, 4),
-    (RacahSymbol, 0),
-    # (PhaseState, 0),
-    # (EnergyFreqWvln, 0),
-    (KeyValuePair, 5),
+    (RacahSymbol, 5),
+    # (PhaseState, None),
+    # (EnergyFreqWvln, None),
+    (KeyValuePair, 6),
 ])
 
 

--- a/pyvalem/state_parser.py
+++ b/pyvalem/state_parser.py
@@ -2,6 +2,8 @@
 A module for parsing strings or sequences of strings into appropriate
 State-like objects or sequences of such objects.
 """
+from collections import OrderedDict
+
 from .state import StateParseError
 from .generic_excited_state import GenericExcitedState
 from .atomic_configuration import AtomicConfiguration
@@ -13,19 +15,23 @@ from .vibrational_state import VibrationalState
 from .racah_symbol import RacahSymbol
 from .key_value_pair import KeyValuePair
 
-STATES = (
-    GenericExcitedState, 
-    AtomicConfiguration,
-    AtomicTermSymbol,
-    DiatomicMolecularConfiguration,
-    MolecularTermSymbol,
-    VibrationalState,
-    RotationalState,
-    RacahSymbol,
-#    PhaseState,
-#    EnergyFreqWvln,
-    KeyValuePair,
-)
+# the following has two purposes: keys determine the order in which the
+# states are parsed, and the values determine the sorting order of states
+# for StatefulSpecies.__repr__.
+STATES = OrderedDict([
+    (GenericExcitedState, 0),
+    (AtomicConfiguration, 1),
+    (AtomicTermSymbol, 2),
+    (DiatomicMolecularConfiguration, 1),
+    (MolecularTermSymbol, 2),
+    (VibrationalState, 3),
+    (RotationalState, 4),
+    (RacahSymbol, 0),
+    # (PhaseState, 0),
+    # (EnergyFreqWvln, 0),
+    (KeyValuePair, 5),
+])
+
 
 def state_parser(s_state):
     """Parse s_state into an appropriate State-like object or list of such."""
@@ -36,15 +42,15 @@ def state_parser(s_state):
     if not isinstance(s_state, str):
         # If we have a sequence of strings, parse them one by one into a list
         # of State-like objects.
-        return [state_parser(s.strip()) for s in s_state] 
+        return [state_parser(s.strip()) for s in s_state]
 
     state = None
     # Try to parse the string s_state into a State-like object by trying each
     # of the possible derived State classes one by one in a particular order.
     for StateClass in STATES:
-         try:
+        try:
             return StateClass(s_state)
-         except StateParseError:
+        except StateParseError:
             pass
-        
+
     raise StateParseError('Could not parse {}'.format(s_state))

--- a/pyvalem/stateful_species.py
+++ b/pyvalem/stateful_species.py
@@ -9,7 +9,7 @@ from .formula import Formula, FormulaParseError
 from .atomic_configuration import AtomicConfiguration
 from .diatomic_molecular_configuration import DiatomicMolecularConfiguration
 from .key_value_pair import KeyValuePair
-from .state_parser import state_parser
+from .state_parser import state_parser, STATES
 
 class StatefulSpeciesError(Exception):
     pass
@@ -33,8 +33,14 @@ class StatefulSpecies:
     def __repr__(self):
         """Return a canonical text representation of the StatefulSpecies."""
         if self.states:
-            return '{} {}'.format(self.formula,
-                                  ';'.join(sorted(map(repr, self.states))))
+            states_sorted = sorted(
+                self.states,
+                key=lambda state: (STATES[type(state)], repr(state))
+            )
+            return '{} {}'.format(
+                self.formula,
+                ';'.join(repr(state) for state in states_sorted)
+            )
         return self.formula.__repr__()
 
     def __eq__(self, other):

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -85,9 +85,22 @@ class ReactionParseTest(unittest.TestCase):
         self.assertEqual(r1 == r3, False)
 
     def test_reaction_repr(self):
-        s_r1 = 'C2H5OH + 3O2 -> 3H2O + 2CO2'
-        r1 = Reaction(s_r1)
-        self.assertTrue(repr(r1) == '3O2 + C2H5OH → 2CO2 + 3H2O')
+        self.assertEqual(
+            repr(Reaction('C2H5OH + 3O2 -> 3H2O + 2CO2')),
+            'C2H5OH + 3O2 → 2CO2 + 3H2O'
+        )
+        self.assertEqual(
+            repr(Reaction('e- + C2 + e- -> C- + C-')),
+            '2e- + C2 → 2C-'
+        )
+        self.assertEqual(
+            repr(Reaction('e- + C2 -> C- + C')),
+            'e- + C2 → C + C-'
+        )
+        self.assertEqual(
+            repr(Reaction('hv + C2 -> C + C')),
+            'hv + C2 → 2C'
+        )
 
 
 if __name__ == '__main__':

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -17,7 +17,7 @@ class ReactionParseTest(unittest.TestCase):
         r1 = Reaction(s_r1)
         self.assertEqual(str(r1), s_r1)
         r2 = Reaction('CO v=1 + O2 J=2;X(3SIGMA-g) → CO2 + O')
-        self.assertEqual(str(r2), 'CO v=1 + O2 J=2;X(3Σ-g) → CO2 + O')
+        self.assertEqual(str(r2), 'CO v=1 + O2 X(3Σ-g);J=2 → CO2 + O')
         self.assertRaises(ReactionParseError, Reaction, 'CO + O2 CO2 + O')
         self.assertRaises(ReactionParseError, Reaction, 'CO + O2 = + CO2 + O')
         self.assertRaises(ReactionParseError, Reaction, 'BeH+ + I2 =⇌ BeI')
@@ -28,9 +28,9 @@ class ReactionParseTest(unittest.TestCase):
         self.assertEqual(r2.reactants[0][1].states[0].__repr__(), 'v=1')
         self.assertEqual(r2.reactants[1][1].states[1].__repr__(), 'X(3Σ-g)')
         self.assertEqual(r2.html, 'CO v=1 + O<sub>2</sub> J=2;'
-            ' X(<sup>3</sup>Σ<sup>-</sup><sub>g</sub>) → CO<sub>2</sub> + O')
+            ' X<sup>3</sup>Σ<sup>-</sup><sub>g</sub> → CO<sub>2</sub> + O')
         self.assertEqual(r2.latex, r'\mathrm{C}\mathrm{O} \; v=1 + '
-                r'\mathrm{O}_{2} \; J=2; \; X({}^{3}\Sigma^-_{g}) \rightarrow '
+                r'\mathrm{O}_{2} \; J=2; \; X{}^{3}\Sigma^-_{g} \rightarrow '
                 r'\mathrm{C}\mathrm{O}_{2} + \mathrm{O}')
 
         s_r3 = 'C6H5OH + 7O2 -> 6CO2 + 3H2O'

--- a/test/test_stateful_species.py
+++ b/test/test_stateful_species.py
@@ -97,12 +97,21 @@ class StatefulSpeciesTest(unittest.TestCase):
 
     def test_stateful_species_repr(self):
         ss1 = StatefulSpecies('C2H2 v2+v1;J=10;X(1SIGMA+u)')
-        self.assertTrue(repr(ss1) == 'C2H2 J=10;X(1Σ+u);ν1+ν2')
+        self.assertTrue(repr(ss1) == 'C2H2 X(1Σ+u);ν1+ν2;J=10')
 
         ss2 = StatefulSpecies('(235U) l=0;***;n=1')
         ss3 = StatefulSpecies('(235U) l=0;n=1;***')
         self.assertEqual(repr(ss2), repr(ss3))
         self.assertEqual(repr(ss2), '(235U) 3*;l=0;n=1')
+
+        for ss_text in ['C+ 4P;2s2.2p1', 'C+ 2s2.2p1;4P']:
+            self.assertEqual(repr(StatefulSpecies(ss_text)),
+                             'C+ 2s2.2p1;4P')
+
+        for ss_text in ['C+ 2P;2s2.2p1', 'C+ 2s2.2p1;2P']:
+            self.assertEqual(repr(StatefulSpecies(ss_text)),
+                             'C+ 2s2.2p1;2P')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changes canonicalisation by `repr()` for `StatefulSpecies` by changing the sorting order of `State` instances.
Now, the `State` type has precedence over alphabetical `State` representation.

The `state_parser.STATES` was changed from the original `tuple` to the `OrderedDict`, so it iterates in the same way as the original sequence, but can be repurposed also for state sorting by adding `int` values representing the sorting order of states in the `StatefulSpecies.__repr__`.
An unit test was added to test for this, and several others were changed, as this change had an externality in `__str__`, which many classes do not implement and therefore is defaulted to the changed `__repr__`.

Lastly, two more broken unit tests were changed to reflect the previous commit removing the parentheses from labeled `MolecularTermSymbol`s.