### PR TITLE
Reaction species map

### DIFF
--- a/pyvalem/reaction.py
+++ b/pyvalem/reaction.py
@@ -83,8 +83,13 @@ class Reaction:
 
     def _parse_species(self, lhs_str, rhs_str):
         """
-        Parse s into n<ss> where n is a stoichiometric coefficient and ss
-        a StatefulSpecies instance.
+        Parse strings of both sides of the reaction string into
+        self.reactants and self.products in the form of lists of
+        (species_count, StatefulSpecies).
+        On the side, also creates maps between species string (as passed
+        to the constructor) and number of species on the side.
+        Those are self.reactants_text_count_map and
+        self.products_text_count_map.
         """
         self.reactants_text_count_map = {}
         self.products_text_count_map = {}

--- a/test/test_reaction.py
+++ b/test/test_reaction.py
@@ -182,6 +182,22 @@ class ReactionParseTest(unittest.TestCase):
         self.assertTrue(r.charge_conserved())
         self.assertTrue(r.stoichiometry_conserved())
 
+    def test_reaction_species_map(self):
+        r = Reaction('e- + C2 + e- -> C- + C-')
+        self.assertEqual(r.reactants_text_count_map, {'e-': 2, 'C2': 1})
+        self.assertEqual(r.products_text_count_map, {'C-': 2})
+        r = Reaction('e- + e- + hv -> ', strict=False)
+        self.assertEqual(r.reactants_text_count_map, {'e-': 2, 'hv': 1})
+        self.assertEqual(r.products_text_count_map, {})
+        r = Reaction('1e- + 1e- + 2hv -> ', strict=False)
+        self.assertEqual(r.reactants_text_count_map, {'e-': 2, 'hv': 2})
+        r = Reaction('e- + O2 X(3Σ-g) -> ', strict=False)
+        self.assertEqual(r.reactants_text_count_map,
+                         {'e-': 1, 'O2 X(3Σ-g)': 1})
+        r = Reaction('e- + O2 X(3SIGMA-g) -> ', strict=False)
+        self.assertEqual(r.reactants_text_count_map,
+                         {'e-': 1, 'O2 X(3SIGMA-g)': 1})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add two more `Reaction` instance attributes:
* `reactants_text_count_map`: `dict[sp_str : str, sp_stoich : int]`
* `products_text_count_map`: `dict[sp_str : str, sp_stoich : int]`

Also adds a simple test for those.

This change is introduced for easier checks if `'e-'` or `'hv'` are on either side of the reaction, without re-parsing the reaction string.